### PR TITLE
Added required parameter to model constructor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ ldapAuth.sublime*
 /nbproject/
 ldap-auth.sublime*
 composer.lock
+.idea

--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,12 @@
 {
-    "name": "strebl/l5-ldap-auth",
+    "name": "mikumakues/ldap-auth",
     "description": "Laravel 5 Active Directory LDAP Authentication driver",
     "keywords": ["laravel", "L5", "LDAP", "Authentication", "Laravel 5"],
     "authors": [
+        {
+            "name": "Manuel Kues",
+            "email": "michael.kues@hotmail.com"
+        },
         {
             "name": "Manuel Strebel",
             "email": "manuel_st@msn.com"

--- a/src/Ccovey/LdapAuth/LdapAuthUserProvider.php
+++ b/src/Ccovey/LdapAuth/LdapAuthUserProvider.php
@@ -211,7 +211,7 @@ class LdapAuthUserProvider implements UserProvider
     {
         $model = '\\' . ltrim($this->model, '\\');
 
-        return new $model;
+        return new $model([]);
     }
 
     /**


### PR DESCRIPTION
Noticed a crash when creating a new model  instance in the LdapAuthUserProvider due to missing parameter ($attributes) for the LdapUser.
