### PR TITLE
Fix for Auth::user() returning the Eloquent model

### DIFF
--- a/src/Ccovey/LdapAuth/LdapAuthUserProvider.php
+++ b/src/Ccovey/LdapAuth/LdapAuthUserProvider.php
@@ -74,6 +74,7 @@ class LdapAuthUserProvider implements UserProvider
             $ldapUserInfo = $this->setInfoArray($infoCollection);
 
             if ($this->model) {
+                $model = $this->createModel()->newQuery()->where($userNameField, $username)->first();
                 if ( ! is_null($model) ) {
                     return $this->addLdapToModel($model, $ldapUserInfo);
                 }


### PR DESCRIPTION
Return the Eloquent model instead of LdapUser when using Auth::user()
