### PR TITLE
Fix #15 - ErrorException if you try to login an account that don't exist and primarygroup is set to true

### DIFF
--- a/src/LdapAuthUserProvider.php
+++ b/src/LdapAuthUserProvider.php
@@ -246,7 +246,7 @@ class LdapAuthUserProvider implements UserProvider
     {
         $groups = explode(',', $groupList);
 
-        return substr($groups[1], '3');
+        return isset($groups[1]) ? substr($groups[1], '3') : null;
     }
 
     /**

--- a/tests/LdapAuthUserProviderTest.php
+++ b/tests/LdapAuthUserProviderTest.php
@@ -23,6 +23,7 @@ class LdapAuthUserProviderTest extends PHPUnit_Framework_TestCase
         $this->config = [
             'fields'   => [
                 'groups' => 'groups',
+                'primarygroup' => 'primarygroup',
             ],
             'userlist' => false,
             'group'    => [],

--- a/tests/LdapAuthUserProviderTest.php
+++ b/tests/LdapAuthUserProviderTest.php
@@ -22,7 +22,7 @@ class LdapAuthUserProviderTest extends PHPUnit_Framework_TestCase
 
         $this->config = [
             'fields'   => [
-                'groups' => 'groups',
+                'groups'       => 'groups',
                 'primarygroup' => 'primarygroup',
             ],
             'userlist' => false,


### PR DESCRIPTION
If you try to authenticate a user which don't exist, you should get false.
But if primarygroup is set to true, an Exception gets thrown.

This PR fixes that issue (#15).

Thanks @spaldos and @elite123 for reporting this issue.
Thanks to @spaldos again for providing the solution.
